### PR TITLE
Add tab support for multiple categories of items

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,3 +14,39 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+ /* Style the tab */
+ .tab {
+  overflow: hidden;
+  border: 1px solid #ccc;
+  background-color: #f1f1f1;
+}
+
+/* Style the buttons that are used to open the tab content */
+.tab button {
+  background-color: inherit;
+  float: left;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  transition: 0.3s;
+}
+
+/* Change background color of buttons on hover */
+.tab button:hover {
+  background-color: #ddd;
+}
+
+/* Create an active/current tablink class */
+.tab button.active {
+  background-color: #ccc;
+}
+
+/* Style the tab content */
+.tabcontent {
+  display: none;
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-top: none;
+} 

--- a/frontend/src/msal.js
+++ b/frontend/src/msal.js
@@ -1,6 +1,12 @@
 import * as Msal from "msal";
 
 const msalInstance = new Msal.UserAgentApplication({
+  /* [NOTE]: The app does not work unless...
+  * -> ClientID is specified
+  * -> authority URL includes ClientID at the end (microsoftonline.com/<CLIENT_ID>)
+  * This information is available in Azure, contact Andrei to gain access to it.
+  * [DEPLOY TODO]: redirectURI needs to be changed to https://rental.mcgilleus.ca/ for the live version
+  */
   auth: {
     clientId: "",
     authority: "https://login.microsoftonline.com/",


### PR DESCRIPTION
## Why?

EUS VP Services wants multiple different types of items, so I've added tabs to only show subsets of all the items.

## How?

Handle this entirely on the front-end by filtering through queried items. This is not the ideal solution, because a database query might be more optimized than always querying all items then filtering client-side, but this platform is not meant to have too many items on it.

### What's new?

![image](https://user-images.githubusercontent.com/15990179/66950783-15b3b380-f027-11e9-910d-62834a7d5959.png)

The app is deployed here for testing: https://rental.mcgilleus.ca/